### PR TITLE
Remove an undesirable slf4j-simple dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 
   val slf4jVersion = "1.7.36"
   implementation("org.slf4j:slf4j-api:$slf4jVersion")
-  implementation("org.slf4j:slf4j-simple:$slf4jVersion")
 
   val jnaVersion = "5.11.0"
   implementation("net.java.dev.jna:jna:$jnaVersion")


### PR DESCRIPTION
Since java-statusnotifier is a library, dependents should include the slf4j implementation they want.